### PR TITLE
Fix golang lint

### DIFF
--- a/cmd/aurad/cmd/testnet.go
+++ b/cmd/aurad/cmd/testnet.go
@@ -194,7 +194,7 @@ func InitTestnet(
 		if err != nil {
 			return err
 		}
-
+		//nolint:staticcheck
 		addr, secret, err := server.GenerateSaveCoinKey(kb, nodeDirName, true, algo)
 		if err != nil {
 			_ = os.RemoveAll(outputDir)

--- a/cmd/aurad/cmd/vestingaccountcmd.go
+++ b/cmd/aurad/cmd/vestingaccountcmd.go
@@ -43,6 +43,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
+			//nolint:staticcheck
 			depCdc := clientCtx.JSONCodec
 			cdc := depCdc.(codec.Codec)
 

--- a/x/aura/types/codec.go
+++ b/x/aura/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+
 	// this line is used by starport scaffolding # 1
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
@@ -18,6 +19,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
+	//nolint:unused
 	amino     = codec.NewLegacyAmino()
 	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -30,5 +30,5 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper.BaseKeeper)
-	cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
+	_ = cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
 }

--- a/x/feegrant/cli/tx.go
+++ b/x/feegrant/cli/tx.go
@@ -2,9 +2,10 @@ package cli
 
 import (
 	"fmt"
-	customfeegrant "github.com/aura-nw/aura/x/feegrant"
 	"strings"
 	"time"
+
+	customfeegrant "github.com/aura-nw/aura/x/feegrant"
 
 	"github.com/spf13/cobra"
 
@@ -66,7 +67,7 @@ Examples:
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			cmd.Flags().Set(flags.FlagFrom, args[0])
+			_ = cmd.Flags().Set(flags.FlagFrom, args[0])
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -210,7 +211,7 @@ Example:
 		),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Flags().Set(flags.FlagFrom, args[0])
+			_ = cmd.Flags().Set(flags.FlagFrom, args[0])
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -75,7 +75,7 @@ func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 func (a AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config sdkclient.TxEncodingConfig, bz json.RawMessage) error {
 	var data feegrant.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
-		_ = sdkerrors.Wrapf(err, "failed to unmarshal %s genesis state", feegrant.ModuleName)
+		return sdkerrors.Wrapf(err, "failed to unmarshal %s genesis state", feegrant.ModuleName)
 	}
 
 	return feegrant.ValidateGenesis(data)

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -3,6 +3,8 @@ package module
 import (
 	"context"
 	"encoding/json"
+	"math/rand"
+
 	customfeegrant "github.com/aura-nw/aura/x/feegrant"
 	customcli "github.com/aura-nw/aura/x/feegrant/cli"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
@@ -20,7 +22,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"math/rand"
 )
 
 var (
@@ -74,7 +75,7 @@ func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 func (a AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config sdkclient.TxEncodingConfig, bz json.RawMessage) error {
 	var data feegrant.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
-		sdkerrors.Wrapf(err, "failed to unmarshal %s genesis state", feegrant.ModuleName)
+		_ = sdkerrors.Wrapf(err, "failed to unmarshal %s genesis state", feegrant.ModuleName)
 	}
 
 	return feegrant.ValidateGenesis(data)
@@ -85,7 +86,7 @@ func (AppModuleBasic) RegisterRESTRoutes(ctx sdkclient.Context, rtr *mux.Router)
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the feegrant module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx sdkclient.Context, mux *runtime.ServeMux) {
-	feegrant.RegisterQueryHandlerClient(context.Background(), mux, feegrant.NewQueryClient(clientCtx))
+	_ = feegrant.RegisterQueryHandlerClient(context.Background(), mux, feegrant.NewQueryClient(clientCtx))
 }
 
 // GetTxCmd returns the root tx command for the feegrant module.


### PR DESCRIPTION
Fix linter when check CI/CD. Most of the case is don't check err